### PR TITLE
Only allow nested to reduce if it is already nested

### DIFF
--- a/assets/lexer.rex
+++ b/assets/lexer.rex
@@ -31,8 +31,8 @@ rule
 #-------------------------------------------------------------------------------
                 {MCOMMENTIN}              { consume_comment(text) }
                 {BOOL}                    { [:BOOL,         to_boolean(text)]}
-                {NUMBER}                  { [:NUMBER,       text.to_i] }
                 {FLOAT}                   { [:FLOAT,        text.to_f] }
+                {NUMBER}                  { [:NUMBER,       text.to_i] }
                 {QUOTE}                   { [:STRING,       consume_string(text)] }
                 {HEREDOCUMENT}            { [:STRING,       consume_heredoc] }
 #-------------------------------------------------------------------------------

--- a/assets/lexer.rex
+++ b/assets/lexer.rex
@@ -95,7 +95,7 @@ inner
       when %r{\$\{\z}
         nested += 1
       when %r{\}\z}
-        nested -= 1
+        nested -= 1 if nested > 0
       when %r{\\\z}
         result += text.chop + @ss.getch
         next

--- a/lib/hcl/lexer.rb
+++ b/lib/hcl/lexer.rb
@@ -157,7 +157,7 @@ class HCLLexer
       when %r{\$\{\z}
         nested += 1
       when %r{\}\z}
-        nested -= 1
+        nested -= 1 if nested > 0
       when %r{\\\z}
         result += text.chop + @ss.getch
         next

--- a/lib/hcl/lexer.rb
+++ b/lib/hcl/lexer.rb
@@ -72,11 +72,11 @@ class HCLLexer
       when (text = @ss.scan(/true|false/))
          action { [:BOOL,         to_boolean(text)]}
 
-      when (text = @ss.scan(/-?\d+/))
-         action { [:NUMBER,       text.to_i] }
-
       when (text = @ss.scan(/\-?\d+\.\d+/))
          action { [:FLOAT,        text.to_f] }
+
+      when (text = @ss.scan(/-?\d+/))
+         action { [:NUMBER,       text.to_i] }
 
       when (text = @ss.scan(/\"/))
          action { [:STRING,       consume_string(text)] }

--- a/lib/hcl/parser.rb
+++ b/lib/hcl/parser.rb
@@ -70,19 +70,19 @@ module_eval(<<'...end parse.y/module_eval...', 'parse.y', 115)
 
 racc_action_table = [
     20,    26,    25,    36,    26,    25,     5,    21,     6,    13,
-    33,    24,    35,    26,    25,    30,     5,    10,     6,    33,
-     5,    28,     6,    -8,    16,    34,    17,     5,    13,     6,
-    -9,    12,    18 ]
+    33,    24,    35,    26,    25,    30,     5,    18,     6,    33,
+     5,    28,     6,    12,    16,    34,    17,     5,    13,     6,
+    -9,    -8,    10 ]
 
 racc_action_check = [
     12,    12,    12,    29,    24,    24,     0,    12,     0,    12,
-    24,    12,    29,    36,    36,    24,    13,     1,    13,    36,
-    27,    13,    27,     5,     9,    27,     9,     3,     9,     3,
-     6,     7,    10 ]
+    24,    12,    29,    36,    36,    24,    13,    10,    13,    36,
+    27,    13,    27,     7,     9,    27,     9,     3,     9,     3,
+     6,     5,     1 ]
 
 racc_action_pointer = [
-    -1,    17,   nil,    20,   nil,    15,    22,    23,   nil,    17,
-    32,   nil,    -2,     9,   nil,   nil,   nil,   nil,   nil,   nil,
+    -1,    32,   nil,    20,   nil,    23,    22,    15,   nil,    17,
+    17,   nil,    -2,     9,   nil,   nil,   nil,   nil,   nil,   nil,
    nil,   nil,   nil,   nil,     1,   nil,   nil,    13,   nil,    -2,
    nil,   nil,   nil,   nil,   nil,   nil,    10,   nil ]
 
@@ -93,18 +93,18 @@ racc_action_default = [
    -21,   -22,   -25,   -26,    -6,   -20,   -24,   -23 ]
 
 racc_goto_table = [
-    11,     3,    14,    31,     1,    22,     2,    19,    23,    15,
-    29,   nil,   nil,   nil,    27,    37,   nil,   nil,   nil,   nil,
+    11,     3,    14,    31,    15,    22,    29,    19,     2,     1,
+    23,   nil,   nil,   nil,    27,    37,   nil,   nil,   nil,   nil,
    nil,   nil,   nil,   nil,    11 ]
 
 racc_goto_check = [
-     4,     3,     5,    12,     1,     5,     2,     7,     8,     9,
-    11,   nil,   nil,   nil,     3,    12,   nil,   nil,   nil,   nil,
+     4,     3,     5,    12,     9,     5,    11,     7,     2,     1,
+     8,   nil,   nil,   nil,     3,    12,   nil,   nil,   nil,   nil,
    nil,   nil,   nil,   nil,     4 ]
 
 racc_goto_pointer = [
-   nil,     4,     6,     1,    -3,    -7,   nil,    -5,    -4,     0,
-   nil,   -14,   -21 ]
+   nil,     9,     8,     1,    -3,    -7,   nil,    -5,    -2,    -5,
+   nil,   -18,   -21 ]
 
 racc_goto_default = [
    nil,   nil,   nil,   nil,     4,   nil,     7,    32,   nil,     8,

--- a/spec/hcl/checker_spec.rb
+++ b/spec/hcl/checker_spec.rb
@@ -3,6 +3,21 @@ RSpec.describe HCL::Checker do
     expect(HCL::Checker::VERSION).not_to be nil
   end
 
+  it 'parses floats' do
+    hcl_string = 'provider "foo" {' \
+                 'foo = 0.1' \
+                 'bar = 1' \
+                 '}'
+    expect(HCL::Checker.parse hcl_string).to eq({
+      "provider" => {
+        "foo" => {
+          "foo" => 0.1,
+          "bar" => 1,
+        }
+      }
+    })
+  end
+
   it 'try to validate a valid HCL' do
     hcl_string = 'provider "aws" {' \
                  'region = "${var.aws_region}"' \

--- a/spec/hcl/checker_spec.rb
+++ b/spec/hcl/checker_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe HCL::Checker do
                  'cidr_block = "10.0.0.0/16"' \
                  'enable_dns_hostnames = true' \
                  'tags {' \
-                 'Name = "Event Store VPC"' \
+                 'Name = "Event {Store} VPC"' \
                  '}' \
                  '}'
     expect(HCL::Checker.valid? hcl_string).to eq(true)


### PR DESCRIPTION
Found a bug where strings including `Foo {Bar} Baz` would parse forever because they nested check would drop below 0 on the `}`
