### PR TITLE
Accept rich type specs

### DIFF
--- a/assets/parse.y
+++ b/assets/parse.y
@@ -62,12 +62,23 @@ rule
        { result = val[0], val[2] }
   |  objectkey EQUAL list
        { result = val[0], val[2] }
-  |  objectkey EQUAL IDENTIFIER LEFTPARENTHESES IDENTIFIER RIGHTPARENTHESES
+  |  objectkey EQUAL IDENTIFIER LEFTPARENTHESES cawabanga RIGHTPARENTHESES
        { result = val[0], "#{val[2]}(#{val[4]})" }
   |  objectkey EQUAL IDENTIFIER
        { result = val[0], val[2] }
   |  block
        { result = val[0] }
+  ;
+
+  cawabanga:
+     IDENTIFIER
+       { result = val[0] }
+  |  object
+       { result = val[0] }
+  |  list
+       { result = val[0] }
+  |  IDENTIFIER LEFTPARENTHESES cawabanga RIGHTPARENTHESES
+       { result = val[0], "#{val[2]}(#{val[4]})" }
   ;
 
   block:
@@ -104,6 +115,8 @@ rule
      number
        { result = val[0] }
   |  STRING
+       { result = val[0] }
+  |  IDENTIFIER
        { result = val[0] }
   | list
        { result = val[0] }

--- a/lib/hcl/parser.rb
+++ b/lib/hcl/parser.rb
@@ -10,7 +10,7 @@ require_relative './lexer'
 
 class HCLParser < Racc::Parser
 
-module_eval(<<'...end parse.y/module_eval...', 'parse.y', 128)
+module_eval(<<'...end parse.y/module_eval...', 'parse.y', 141)
   #//
   #//       HCL is unclear on what one should do when duplicate
   #//       keys are encountered.
@@ -69,50 +69,58 @@ module_eval(<<'...end parse.y/module_eval...', 'parse.y', 128)
 ##### State transition tables begin ###
 
 racc_action_table = [
-    22,    29,    28,    10,    12,    26,    43,    23,     5,    14,
-     6,    27,    29,    28,     5,    42,     6,   -10,    37,    31,
-    14,   -11,    27,    34,    29,    28,     5,     5,     6,     6,
-    37,    40,    14,    17,    27,    18,    13,    14,    19,    20,
-    32,    41,    44 ]
+    22,    29,    28,    10,    43,    26,    47,    23,    14,    14,
+    27,    27,    29,    28,    12,    46,    38,    17,    37,    18,
+    14,    14,    27,    34,    29,    28,   -10,    43,    38,   -11,
+    37,    14,    14,    27,    27,     5,     5,     6,     6,    13,
+    31,    41,     5,     5,     6,     6,    19,    20,    32,    48,
+    49,    52 ]
 
 racc_action_check = [
-    13,    13,    13,     1,     4,    13,    33,    13,     0,    13,
-     0,    13,    27,    27,    14,    33,    14,     5,    27,    14,
-    27,     6,    27,    27,    43,    43,    30,     3,    30,     3,
-    43,    30,    43,     9,    43,     9,     7,     9,    10,    11,
-    26,    32,    41 ]
+    13,    13,    13,     1,    32,    13,    33,    13,    32,    13,
+    32,    13,    27,    27,     4,    33,    27,     9,    27,     9,
+    27,     9,    27,    27,    47,    47,     5,    49,    47,     6,
+    47,    49,    47,    49,    47,    14,    30,    14,    30,     7,
+    14,    30,     0,     3,     0,     3,    10,    11,    26,    42,
+    43,    51 ]
 
 racc_action_pointer = [
-     1,     3,   nil,    20,    -1,     9,    13,    28,   nil,    26,
-    38,    34,   nil,    -2,     7,   nil,   nil,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,    25,     9,   nil,   nil,
-    19,   nil,    34,     1,   nil,   nil,   nil,   nil,   nil,   nil,
-   nil,    26,   nil,    21,   nil,   nil ]
+    35,     3,   nil,    36,     9,    18,    21,    31,   nil,    10,
+    46,    42,   nil,    -2,    28,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,    33,     9,   nil,   nil,
+    29,   nil,    -3,     1,   nil,   nil,   nil,   nil,   nil,   nil,
+   nil,   nil,    33,    35,   nil,   nil,   nil,    21,   nil,    20,
+   nil,    35,   nil ]
 
 racc_action_default = [
-    -2,   -35,    -1,    -3,    -5,   -22,   -23,   -35,   -19,   -35,
-   -35,    -7,    -4,   -35,   -35,   -20,   -21,   -22,   -23,    46,
-    -6,   -12,   -13,   -14,   -15,   -16,   -18,   -35,   -33,   -34,
-   -35,    -9,   -35,   -35,   -25,   -26,   -29,   -30,   -31,   -32,
-    -8,   -35,   -24,   -28,   -17,   -27 ]
+    -2,   -40,    -1,    -3,    -5,   -26,   -27,   -40,   -19,   -40,
+   -40,    -7,    -4,   -40,   -40,   -24,   -25,   -26,   -27,    53,
+    -6,   -12,   -13,   -14,   -15,   -16,   -18,   -40,   -38,   -39,
+   -40,    -9,   -40,   -40,   -29,   -30,   -33,   -34,   -35,   -36,
+   -37,    -8,   -40,   -20,   -21,   -22,   -28,   -32,   -17,   -40,
+   -31,   -40,   -23 ]
 
 racc_goto_table = [
-    11,    35,     3,    15,     1,     2,    21,    24,    25,    16,
-    33,   nil,   nil,   nil,   nil,   nil,    30,    45,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,    11 ]
+    15,    25,    11,     3,    24,    35,     1,    42,     2,    21,
+    16,    33,   nil,   nil,   nil,   nil,   nil,    30,   nil,   nil,
+    45,   nil,   nil,    44,    51,    50,   nil,   nil,   nil,    11,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,    45,   nil,   nil,
+    44 ]
 
 racc_goto_check = [
-     4,    12,     3,     5,     1,     2,     7,     5,     8,     9,
-    11,   nil,   nil,   nil,   nil,   nil,     3,    12,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,     4 ]
+     5,     8,     4,     3,     5,    13,     1,     9,     2,     7,
+    10,    12,   nil,   nil,   nil,   nil,   nil,     3,   nil,   nil,
+     8,   nil,   nil,     5,     9,    13,   nil,   nil,   nil,     4,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,     8,   nil,   nil,
+     5 ]
 
 racc_goto_pointer = [
-   nil,     4,     5,     2,    -3,    -6,   nil,    -7,    -5,     0,
-   nil,   -17,   -26 ]
+   nil,     6,     8,     3,    -1,    -9,   nil,    -4,   -12,   -25,
+     1,   nil,   -16,   -22 ]
 
 racc_goto_default = [
-   nil,   nil,   nil,   nil,     4,    39,     7,    36,    38,     8,
-     9,   nil,   nil ]
+   nil,   nil,   nil,   nil,     4,    40,     7,    36,    39,   nil,
+     8,     9,   nil,   nil ]
 
 racc_reduce_table = [
   0, 0, :racc_error,
@@ -135,25 +143,30 @@ racc_reduce_table = [
   6, 24, :_reduce_17,
   3, 24, :_reduce_18,
   1, 24, :_reduce_19,
-  2, 29, :_reduce_20,
-  2, 29, :_reduce_21,
-  1, 30, :_reduce_22,
-  1, 30, :_reduce_23,
-  3, 28, :_reduce_24,
-  2, 28, :_reduce_25,
+  1, 29, :_reduce_20,
+  1, 29, :_reduce_21,
+  1, 29, :_reduce_22,
+  4, 29, :_reduce_23,
+  2, 30, :_reduce_24,
+  2, 30, :_reduce_25,
   1, 31, :_reduce_26,
-  3, 31, :_reduce_27,
-  2, 31, :_reduce_28,
-  1, 32, :_reduce_29,
+  1, 31, :_reduce_27,
+  3, 28, :_reduce_28,
+  2, 28, :_reduce_29,
   1, 32, :_reduce_30,
-  1, 32, :_reduce_31,
-  1, 32, :_reduce_32,
-  1, 27, :_reduce_33,
-  1, 27, :_reduce_34 ]
+  3, 32, :_reduce_31,
+  2, 32, :_reduce_32,
+  1, 33, :_reduce_33,
+  1, 33, :_reduce_34,
+  1, 33, :_reduce_35,
+  1, 33, :_reduce_36,
+  1, 33, :_reduce_37,
+  1, 27, :_reduce_38,
+  1, 27, :_reduce_39 ]
 
-racc_reduce_n = 35
+racc_reduce_n = 40
 
-racc_shift_n = 46
+racc_shift_n = 53
 
 racc_token_table = {
   false => 0,
@@ -227,6 +240,7 @@ Racc_token_to_s_table = [
   "objectkey",
   "number",
   "list",
+  "cawabanga",
   "block",
   "block_id",
   "listitems",
@@ -368,84 +382,84 @@ module_eval(<<'.,.,', 'parse.y', 69)
 
 module_eval(<<'.,.,', 'parse.y', 74)
   def _reduce_20(val, _values, result)
-     result = val[0], val[1]
+     result = val[0]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parse.y', 76)
   def _reduce_21(val, _values, result)
-     result = val[0], {val[1][0] => val[1][1]}
+     result = val[0]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parse.y', 81)
+module_eval(<<'.,.,', 'parse.y', 78)
   def _reduce_22(val, _values, result)
      result = val[0]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parse.y', 83)
+module_eval(<<'.,.,', 'parse.y', 80)
   def _reduce_23(val, _values, result)
+     result = val[0], "#{val[2]}(#{val[4]})"
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parse.y', 85)
+  def _reduce_24(val, _values, result)
+     result = val[0], val[1]
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parse.y', 87)
+  def _reduce_25(val, _values, result)
+     result = val[0], {val[1][0] => val[1][1]}
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parse.y', 92)
+  def _reduce_26(val, _values, result)
      result = val[0]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parse.y', 88)
-  def _reduce_24(val, _values, result)
-     result = val[1]
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parse.y', 90)
-  def _reduce_25(val, _values, result)
-     return
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parse.y', 95)
-  def _reduce_26(val, _values, result)
-     result = [val[0]]
-    result
-  end
-.,.,
-
-module_eval(<<'.,.,', 'parse.y', 97)
+module_eval(<<'.,.,', 'parse.y', 94)
   def _reduce_27(val, _values, result)
-     result = val[0] << val[2]
+     result = val[0]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parse.y', 99)
   def _reduce_28(val, _values, result)
-     result = val[0]
+     result = val[1]
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parse.y', 104)
+module_eval(<<'.,.,', 'parse.y', 101)
   def _reduce_29(val, _values, result)
-     result = val[0]
+     return
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parse.y', 106)
   def _reduce_30(val, _values, result)
-     result = val[0]
+     result = [val[0]]
     result
   end
 .,.,
 
 module_eval(<<'.,.,', 'parse.y', 108)
   def _reduce_31(val, _values, result)
-     result = val[0]
+     result = val[0] << val[2]
     result
   end
 .,.,
@@ -466,6 +480,41 @@ module_eval(<<'.,.,', 'parse.y', 115)
 
 module_eval(<<'.,.,', 'parse.y', 117)
   def _reduce_34(val, _values, result)
+     result = val[0]
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parse.y', 119)
+  def _reduce_35(val, _values, result)
+     result = val[0]
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parse.y', 121)
+  def _reduce_36(val, _values, result)
+     result = val[0]
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parse.y', 123)
+  def _reduce_37(val, _values, result)
+     result = val[0]
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parse.y', 128)
+  def _reduce_38(val, _values, result)
+     result = val[0]
+    result
+  end
+.,.,
+
+module_eval(<<'.,.,', 'parse.y', 130)
+  def _reduce_39(val, _values, result)
      result = val[0]
     result
   end

--- a/spec/hcl1/basic_spec.rb
+++ b/spec/hcl1/basic_spec.rb
@@ -14,6 +14,21 @@ RSpec.describe HCL::Checker do
     })
   end
 
+  it 'parses rich value types' do
+    hcl_string = %(variable "foo" {
+      type = map(object({
+        a_string     = string,
+        a_number     = number,
+        a_bool       = bool,
+        a_list       = list(string),
+        a_set        = set(number),
+        a_map        = map(number),
+        a_tuple      = tuple([string, number, bool])
+        a_any        = any
+      }))
+    })
+  end
+
   it 'try to validate a valid HCL' do
     hcl_string = 'provider "aws" {' \
                  'region = "${var.aws_region}"' \


### PR DESCRIPTION
Opening this early for feedback. It adds support for Terraform 0.12's rich type specs and should eventually fix #12.

My main question for the now is if is it ok to augment the `list` rule? Maybe this makes the parser accept more than it should.

And don't worry about the `cawabanga` rule. I'll come up with a better name before this gets merged. I'm also open to suggestions.